### PR TITLE
 Pass a deployment comment to the deployment form

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -31,6 +31,9 @@ class DeploymentsController < ApplicationController
   def new
     @deployment = @stage.deployments.new
     @deployment.task = params[:task]
+
+    # Allow description to be passed in via a URL parameter
+    @deployment.description = params[:description]
     
     if params[:repeat]
       @original = @stage.deployments.find(params[:repeat])


### PR DESCRIPTION
I made a tiny change to scratch a itch I mentioned in the webistrano issue tracker: https://github.com/peritor/webistrano/issues/#issue/12

In order to be able to pass a deployment comment to the deployment form, add the following ruby code after line 33 of /var/www/webistrano/app/controllers/deployments_controller.rb:

```
# Allow description url var to be passed in the URL
@deployment.description = params[:description]
```

Now the description url variable can be used to pre-fill the deployment comment, e.g.  http://webistrano.example.com:8000/projects/1/stages/1/deployments/new?task=deploy&description=my%20comment. We do this to get some integration with the trac bug tracking software.
