### PR TITLE
Add a missing backtick to the unicorn_restart_cmd template

### DIFF
--- a/lib/webistrano/template/unicorn.rb
+++ b/lib/webistrano/template/unicorn.rb
@@ -31,7 +31,7 @@ module Webistrano
         end
 
         def unicorn_restart_cmd
-          "kill -USR2 `cat #{unicorn_pid}"
+          "kill -USR2 `cat #{unicorn_pid}`"
         end
       
         namespace :webistrano do


### PR DESCRIPTION
This is a simple fix for a typo in the unicorn template.
