### PR TITLE
Run Webistrano under Pow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ gem "exception_notification", "2.3.3.0"
 group :test do
   gem "mocha", "0.9.8"
 end
+
+group :development do
+  gem "powder"
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require File.dirname(__FILE__) + '/config/environment'
+run ActionController::Dispatcher.new


### PR DESCRIPTION
This commit allows you to run webistrano under [Pow](http://pow.cx/) and installs the [poweder gem](https://github.com/Rodreegez/powder) in the development environment to make using Pow even easier.

Thanks,
Nathen
