### PR TITLE
Fixes "Attempt to call private method" error

### DIFF
--- a/lib/webistrano/deployer.rb
+++ b/lib/webistrano/deployer.rb
@@ -22,7 +22,7 @@ module Webistrano
     
       @deployment = deployment
       
-      if(@deployment.task && !@deployment.new_record?)
+      if(!@deployment[:task].nil? && !@deployment.new_record?)
         # a read deployment
         @logger = Webistrano::Logger.new(deployment)
         @logger.level = Webistrano::Logger::TRACE


### PR DESCRIPTION
This resolves an error with the StagesController trying to show a stage.  It's throwing an error as shown below.

Thanks,
Nathen 

NoMethodError in StagesController#show

Attempt to call private method

RAILS_ROOT: /Users/nharvey/projects/webistrano
Application Trace | Framework Trace | Full Trace

/Users/nharvey/projects/webistrano/vendor/bundler/ruby/1.8/gems/activerecord-2.3.11/lib/active_record/attribute_methods.rb:236:in `method_missing'
/Users/nharvey/projects/webistrano/lib/webistrano/deployer.rb:25:in`initialize'
/Users/nharvey/projects/webistrano/app/models/stage.rb:125:in `new'
/Users/nharvey/projects/webistrano/app/models/stage.rb:125:in`list_tasks'
/Users/nharvey/projects/webistrano/app/controllers/stages_controller.rb:17:in `show'
/Users/nharvey/projects/webistrano/app/controllers/application_controller.rb:24:in`set_timezone'

Request

Parameters:
{"project_id"=>"1",
 "id"=>"1"}

Show session dump
Response

Headers:
{"Content-Type"=>"",
 "Cache-Control"=>"no-cache"}
