### PR TITLE
Optimize queries for projects with many deployments.

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -78,12 +78,12 @@ class Role < ActiveRecord::Base
   
   # tells if this role had a successful setup
   def setup_done?
-    deployed_at_least_once? && self.deployments.first(:conditions => {"deployments.task" => Deployment::SETUP_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS}).present?
+    deployed_at_least_once? && self.deployments.exists?(:conditions => {"deployments.task" => Deployment::SETUP_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS})
   end
   
   # tells if this role had a successful deployment (deploy)
   def deployed?
-    deployed_at_least_once? && self.deployments.first(:conditions => {"deployments.task" => Deployment::DEPLOY_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS}).present?
+    deployed_at_least_once? && self.deployments.exists?(:conditions => {"deployments.task" => Deployment::DEPLOY_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS})
   end
   
   # tells if this role had any deployment at all

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -78,17 +78,17 @@ class Role < ActiveRecord::Base
   
   # tells if this role had a successful setup
   def setup_done?
-    deployed_at_least_once? && self.deployments.any?{|x| Deployment::SETUP_TASKS.include?(x.task) && x.success? }
+    deployed_at_least_once? && self.deployments.first(:conditions => {"deployments.task" => Deployment::SETUP_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS}).present?
   end
   
   # tells if this role had a successful deployment (deploy)
   def deployed?
-    deployed_at_least_once? && self.deployments.any?{|x| Deployment::DEPLOY_TASKS.include?(x.task) && x.success? }
+    deployed_at_least_once? && self.deployments.first(:conditions => {"deployments.task" => Deployment::DEPLOY_TASKS, "deployments.status" => Deployment::STATUS_SUCCESS}).present?
   end
   
   # tells if this role had any deployment at all
   def deployed_at_least_once?
-    !self.deployments.empty?
+    self.deployments.exists?
   end
   
   def status


### PR DESCRIPTION
It gets super slow when you've had a lot of deployments and many hosts.  These changes optimizes the queries for role and deployment look ups.
