### PR TITLE
Replaced dead links on Dashboard view

### DIFF
--- a/app/views/projects/_welcome.html.erb
+++ b/app/views/projects/_welcome.html.erb
@@ -1,0 +1,22 @@
+<fieldset class="fieldset">
+  <legend>Introduction and help</legend>
+  <div style="float: right; padding: 10px 5px 5px 5px;">
+    <a href="https://github.com/peritor/webistrano" target="_blank"><%= image_tag('peritor_theme/webistrano_screenshot.png', :border => '0', :width => '200', :height => '151')%></a>
+  </div>
+  <div style="padding-top: 5px;">
+   Welcome to Webistrano. Your first steps should be to create a project with a stage.
+   This stage can then be deployed once you made at least one host known to Webistrano.
+   <br /><br />
+   For help and more documentation, see
+   <br />
+   <ul>
+     <li><a href="https://github.com/peritor/webistrano/wiki">Wiki</a></li>
+     <li><a href="https://github.com/peritor/webistrano/wiki/Configuration-Parameters">Configuration Parameters</a></li>
+     <li><a href="https://github.com/peritor/webistrano/wiki/FAQ---Frequently-Asked-Questions">FAQ</a></li>
+   </ul>
+   <br />
+   Webistrano is Open Source. Paid support is available by <a href="http://www.peritor.com">Peritor Consulting</a>.
+  </div>
+</fieldset>
+
+<br />

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -1,25 +1,4 @@
-<fieldset class="fieldset">
-  <legend>Introduction and help</legend>
-  <div style="float: right; padding: 10px 5px 5px 5px;">
-    <a href="https://github.com/peritor/webistrano" target="_blank"><%= image_tag('peritor_theme/webistrano_screenshot.png', :border => '0', :width => '200', :height => '151')%></a>
-  </div>
-  <div style="padding-top: 5px;">
-   Welcome to Webistrano. Your first steps should be to create a project with a stage.
-   This stage can then be deployed once you made at least one host known to Webistrano.
-   <br /><br />
-   For help and more documentation, see
-   <br />
-   <ul>
-     <li><a href="https://github.com/peritor/webistrano/wiki">Wiki</a></li>
-     <li><a href="https://github.com/peritor/webistrano/wiki/Configuration-Parameters">Configuration Parameters</a></li>
-     <li><a href="https://github.com/peritor/webistrano/wiki/FAQ---Frequently-Asked-Questions">FAQ</a></li>
-   </ul>
-   <br />
-   Webistrano is Open Source. Paid support is available by <a href="http://www.peritor.com">Peritor Consulting</a>.
-  </div>
-</fieldset>
-
-<br />
+<%= render :partial => 'projects/welcome' %>
 
 <fieldset class="fieldset">
   <legend>Recent deployments</legend>

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -1,7 +1,7 @@
 <fieldset class="fieldset">
   <legend>Introduction and help</legend>
   <div style="float: right; padding: 10px 5px 5px 5px;">
-    <a href="http://labs.peritor.com/webistrano" target="_blank"><%= image_tag('peritor_theme/webistrano_screenshot.png', :border => '0', :width => '200', :height => '151')%></a>
+    <a href="https://github.com/peritor/webistrano" target="_blank"><%= image_tag('peritor_theme/webistrano_screenshot.png', :border => '0', :width => '200', :height => '151')%></a>
   </div>
   <div style="padding-top: 5px;">
    Welcome to Webistrano. Your first steps should be to create a project with a stage.

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -10,9 +10,9 @@
    For help and more documentation, see
    <br />
    <ul>
-     <li><a href="http://labs.peritor.com/webistrano/">Wiki</a></li>
-     <li><a href="http://labs.peritor.com/webistrano/wiki/ConfigurationParameter">Configuration Parameter</a></li>
-     <li><a href="http://labs.peritor.com/webistrano/wiki/FAQ">FAQ</a></li>
+     <li><a href="https://github.com/peritor/webistrano/wiki">Wiki</a></li>
+     <li><a href="https://github.com/peritor/webistrano/wiki/Configuration-Parameters">Configuration Parameters</a></li>
+     <li><a href="https://github.com/peritor/webistrano/wiki/FAQ---Frequently-Asked-Questions">FAQ</a></li>
    </ul>
    <br />
    Webistrano is Open Source. Paid support is available by <a href="http://www.peritor.com">Peritor Consulting</a>.

--- a/lib/webistrano/template/jaguar.rb
+++ b/lib/webistrano/template/jaguar.rb
@@ -1,18 +1,15 @@
 module Webistrano
   module Template
-    module Base
+    module Jaguar
       CONFIG = {
         :application => 'your_app_name',
-        :scm => 'subversion',
-        :deploy_via => ':checkout',
-        :scm_username => 'your_SVN_user',
-        :scm_password => 'your_SVN_password',
-        :user => 'deployment_user(SSH login)',
-        :password => 'deployment_user(SSH user) password',
-        :runner => 'user to run as with sudo',
-        :use_sudo => 'true',
-        :deploy_to => '/path/to/deployment_base',
-        :repository => 'https://svn.example.com/project/trunk'
+        :branch      => 'master',
+        :scm         => 'git',
+        :deploy_via  => ':remote_cache',
+        :user        => 'deployer',
+        :use_sudo    => 'false',
+        :deploy_to   => '/srv/www',
+        :repository  => 'bitbucket:jaguar/repo'
       }.freeze
       
       DESC = <<-'EOS'

--- a/lib/webistrano/template/unicorn.rb
+++ b/lib/webistrano/template/unicorn.rb
@@ -2,15 +2,14 @@ module Webistrano
   module Template
     module Unicorn
 
-      CONFIG = Webistrano::Template::Rails::CONFIG.dup.merge({
-                                                                 :unicorn_workers => '8',
+      CONFIG = Webistrano::Template::Jaguar::CONFIG.dup.merge({
+                                                                 :rails_env               => 'set-rails-env',
+                                                                 :unicorn_workers         => '4',
                                                                  :unicorn_workers_timeout => '30',
-                                                                 :unicorn_user => 'user',
-                                                                 :unicorn_group => 'group',
-                                                                 :unicorn_bin => 'bundle exec unicorn',
-                                                                 :unicorn_socket => 'Absolute path to Unicorn socket',
-                                                                 :unicorn_config => "Absolute path to Unicorn configuration",
-                                                                 :unicorn_pid => 'Absolute path to the pid of the Unicorn process'
+                                                                 :unicorn_user            => 'deployer',
+                                                                 :unicorn_group           => 'deployer',
+                                                                 :unicorn_bin             => 'bundle exec unicorn_rails',
+                                                                 :unicorn_pid             => '#{deploy_to}/current/tmp/pids/unicorn.pid'
                                                              }).freeze
 
       DESC = <<-'EOS'
@@ -20,10 +19,10 @@ module Webistrano
         unicorn signals instead.
       EOS
 
-      TASKS = Webistrano::Template::Base::TASKS + <<-'EOS'
+      TASKS = Webistrano::Template::Jaguar::TASKS + <<-'EOS'
 
         def unicorn_start_cmd
-          "cd #{current_path} && #{unicorn_bin} -c #{unicorn_config} -E #{rails_env} -D"
+          "cd #{current_path} && #{unicorn_bin} -E #{rails_env} -D"
         end
 
         def unicorn_stop_cmd


### PR DESCRIPTION
The projects#dashboard view contains links to URLs (on http://labs.peritor.com) which do not exist.

This commit replaces those links with links to the Github wiki for each of these pages.
