### PR TITLE
Permit user to chose auth methods from Webistrano's configuration.

### DIFF
--- a/lib/webistrano/template/base.rb
+++ b/lib/webistrano/template/base.rb
@@ -28,7 +28,7 @@ module Webistrano
         # set Net::SSH ssh options through normal variables
         # at the moment only one SSH key is supported as arrays are not
         # parsed correctly by Webistrano::Deployer.type_cast (they end up as strings)
-        [:ssh_port, :ssh_keys].each do |ssh_opt|
+        [:ssh_port, :ssh_keys, :ssh_auth_methods].each do |ssh_opt|
           if exists? ssh_opt
             logger.important("SSH options: setting #{ssh_opt} to: #{fetch(ssh_opt)}")
             ssh_options[ssh_opt.to_s.gsub(/ssh_/, '').to_sym] = fetch(ssh_opt)


### PR DESCRIPTION
Used to fix a Ruby Net::SSH bug.
