### PR TITLE
Update unicorn.rb

### DIFF
--- a/lib/webistrano/template/unicorn.rb
+++ b/lib/webistrano/template/unicorn.rb
@@ -31,7 +31,7 @@ module Webistrano
         end
 
         def unicorn_restart_cmd
-          "kill -USR2 `cat #{unicorn_pid}"
+          "kill -USR2 `cat #{unicorn_pid}`"
         end
       
         namespace :webistrano do


### PR DESCRIPTION
BUG: Missing ` on unicorn_restart_cmd causes unexpected EOF error in shell side.
